### PR TITLE
feat: add context package for loading project config and spec

### DIFF
--- a/internal/context/cobra.go
+++ b/internal/context/cobra.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+package context
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+// FromCommand extracts the daco Context from a cobra.Command's context.
+// Returns nil if no Context is stored.
+func FromCommand(cmd *cobra.Command) *Context {
+	return From(cmd.Context())
+}
+
+// RequireFromCommand extracts the daco Context from a cobra.Command's context,
+// returning an error if not found.
+func RequireFromCommand(cmd *cobra.Command) (*Context, error) {
+	ctx := FromCommand(cmd)
+	if ctx == nil {
+		return nil, errors.New("project context not loaded")
+	}
+	return ctx, nil
+}
+
+// PreRunLoad returns a PersistentPreRunE function that loads the project
+// context and stores it in the command's context.
+func PreRunLoad(cmd *cobra.Command, _ []string) error {
+	ctx, err := Load(cmd.Context())
+	if err != nil {
+		return err
+	}
+	cmd.SetContext(ctx)
+	return nil
+}

--- a/internal/context/cobra_test.go
+++ b/internal/context/cobra_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+package context
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromCommand(t *testing.T) {
+	testDir, err := filepath.Abs("testdata/valid")
+	require.NoError(t, err)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	require.NoError(t, os.Chdir(testDir))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	// Before PreRunLoad
+	assert.Nil(t, FromCommand(cmd))
+
+	// After PreRunLoad
+	require.NoError(t, PreRunLoad(cmd, nil))
+	dacoCtx := FromCommand(cmd)
+	require.NotNil(t, dacoCtx)
+	assert.Equal(t, "My Data Product", dacoCtx.Spec.Info.Title)
+}
+
+func TestRequireFromCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupDir  string // testdata path, empty means no setup needed
+		loadFirst bool   // whether to call PreRunLoad before RequireFromCommand
+		wantErr   bool
+		wantTitle string
+	}{
+		{
+			name:      "not loaded",
+			setupDir:  "",
+			loadFirst: false,
+			wantErr:   true,
+		},
+		{
+			name:      "loaded",
+			setupDir:  "testdata/valid",
+			loadFirst: true,
+			wantErr:   false,
+			wantTitle: "My Data Product",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origDir, _ := os.Getwd()
+			defer func() { _ = os.Chdir(origDir) }()
+
+			if tt.setupDir != "" {
+				testDir, err := filepath.Abs(tt.setupDir)
+				require.NoError(t, err)
+				require.NoError(t, os.Chdir(testDir))
+			}
+
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+
+			if tt.loadFirst {
+				require.NoError(t, PreRunLoad(cmd, nil))
+			}
+
+			dacoCtx, err := RequireFromCommand(cmd)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTitle, dacoCtx.Spec.Info.Title)
+		})
+	}
+}
+
+func TestPreRunLoad_WithCommandExecution(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string // testdata path, empty means use t.TempDir()
+		wantErr   error
+		wantTitle string
+		wantPath  string
+	}{
+		{
+			name:      "valid project",
+			dir:       "testdata/valid",
+			wantErr:   nil,
+			wantTitle: "My Data Product",
+			wantPath:  "spec",
+		},
+		{
+			name:    "not initialized",
+			dir:     "",
+			wantErr: ErrNotInitialized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var testDir string
+			if tt.dir == "" {
+				testDir = t.TempDir()
+			} else {
+				var err error
+				testDir, err = filepath.Abs(tt.dir)
+				require.NoError(t, err)
+			}
+
+			origDir, _ := os.Getwd()
+			defer func() { _ = os.Chdir(origDir) }()
+			require.NoError(t, os.Chdir(testDir))
+
+			var capturedCtx *Context
+
+			rootCmd := &cobra.Command{
+				Use:               "test",
+				PersistentPreRunE: PreRunLoad,
+			}
+
+			subCmd := &cobra.Command{
+				Use: "sub",
+				RunE: func(cmd *cobra.Command, args []string) error {
+					ctx, requireErr := RequireFromCommand(cmd)
+					capturedCtx = ctx
+					return requireErr
+				},
+			}
+			rootCmd.AddCommand(subCmd)
+
+			rootCmd.SetArgs([]string{"sub"})
+			err := rootCmd.ExecuteContext(context.Background())
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, capturedCtx)
+			assert.Equal(t, tt.wantTitle, capturedCtx.Spec.Info.Title)
+			assert.Equal(t, tt.wantPath, capturedCtx.Config.Path)
+		})
+	}
+}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+// Package context provides project context loading for CLI commands.
+package context
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dacolabs/cli/internal/config"
+	"github.com/dacolabs/cli/internal/opendpi"
+)
+
+var (
+	// ErrNotInitialized indicates no daco.yaml was found in the current directory.
+	ErrNotInitialized = errors.New("not in a daco project (daco.yaml not found)")
+
+	// ErrInvalidConfig indicates the config file exists but is invalid.
+	ErrInvalidConfig = errors.New("invalid configuration")
+
+	// ErrSpecNotFound indicates the spec file referenced by config doesn't exist.
+	ErrSpecNotFound = errors.New("spec file not found")
+
+	// ErrInvalidSpec indicates the spec file exists but couldn't be parsed.
+	ErrInvalidSpec = errors.New("invalid OpenDPI spec")
+)
+
+// ConfigFileName is the name of the daco configuration file.
+const ConfigFileName = "daco.yaml"
+
+// contextKey is used to store Context in context.Context.
+type contextKey struct{}
+
+// Context holds the resolved project configuration and parsed OpenDPI spec.
+type Context struct {
+	// Config is the fully resolved configuration (with inheritance applied).
+	Config *config.Config
+
+	// Spec is the parsed OpenDPI specification.
+	Spec *opendpi.Spec
+}
+
+// Load loads the project context from the current working directory and
+// returns a new context.Context with the daco Context stored in it.
+func Load(ctx context.Context) (context.Context, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	configPath := filepath.Join(cwd, ConfigFileName)
+	if _, statErr := os.Stat(configPath); os.IsNotExist(statErr) {
+		return nil, ErrNotInitialized
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
+
+	if validateErr := cfg.ValidateResolved(); validateErr != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidConfig, validateErr)
+	}
+
+	specDir := cfg.Path
+	if !filepath.IsAbs(specDir) {
+		specDir = filepath.Join(cwd, specDir)
+	}
+
+	specPath, parser := findSpecFile(specDir)
+	if specPath == "" {
+		return nil, fmt.Errorf("%w: no opendpi.yaml or opendpi.json in %s", ErrSpecNotFound, specDir)
+	}
+
+	f, err := os.Open(specPath) //nolint:gosec // specPath is derived from config
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSpecNotFound, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	spec, err := parser.Parse(f, os.DirFS(specDir))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidSpec, err)
+	}
+
+	dacoCtx := &Context{
+		Config: cfg,
+		Spec:   spec,
+	}
+
+	return context.WithValue(ctx, contextKey{}, dacoCtx), nil
+}
+
+// findSpecFile looks for opendpi.yaml or opendpi.json in the given directory.
+// Returns the path and parser if found, or empty string if not found.
+func findSpecFile(dir string) (string, opendpi.Parser) {
+	yamlPath := filepath.Join(dir, "opendpi.yaml")
+	if _, err := os.Stat(yamlPath); err == nil {
+		return yamlPath, opendpi.YAML
+	}
+
+	jsonPath := filepath.Join(dir, "opendpi.json")
+	if _, err := os.Stat(jsonPath); err == nil {
+		return jsonPath, opendpi.JSON
+	}
+
+	return "", opendpi.Parser{}
+}
+
+// From extracts the daco Context from a context.Context.
+// Returns nil if no Context is stored.
+func From(ctx context.Context) *Context {
+	if dacoCtx, ok := ctx.Value(contextKey{}).(*Context); ok {
+		return dacoCtx
+	}
+	return nil
+}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+package context
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string // relative to testdata, empty means use t.TempDir()
+		wantErr   error
+		wantTitle string // only checked if wantErr is nil
+		wantPath  string // only checked if wantErr is nil
+	}{
+		{
+			name:    "not initialized",
+			dir:     "", // empty dir with no daco.yaml
+			wantErr: ErrNotInitialized,
+		},
+		{
+			name:    "invalid config",
+			dir:     "testdata/invalid-config",
+			wantErr: ErrInvalidConfig,
+		},
+		{
+			name:    "spec not found",
+			dir:     "testdata/missing-spec",
+			wantErr: ErrSpecNotFound,
+		},
+		{
+			name:      "valid",
+			dir:       "testdata/valid",
+			wantErr:   nil,
+			wantTitle: "My Data Product",
+			wantPath:  "spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var testDir string
+			if tt.dir == "" {
+				testDir = t.TempDir()
+			} else {
+				var err error
+				testDir, err = filepath.Abs(tt.dir)
+				require.NoError(t, err)
+			}
+
+			origDir, _ := os.Getwd()
+			defer func() { _ = os.Chdir(origDir) }()
+			require.NoError(t, os.Chdir(testDir))
+
+			ctx, err := Load(context.Background())
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			dacoCtx := From(ctx)
+			require.NotNil(t, dacoCtx)
+			assert.Equal(t, tt.wantPath, dacoCtx.Config.Path)
+			assert.Equal(t, tt.wantTitle, dacoCtx.Spec.Info.Title)
+		})
+	}
+}
+
+func TestFrom_NoContextStored(t *testing.T) {
+	assert.Nil(t, From(context.Background()))
+}

--- a/internal/context/testdata/invalid-config/daco.yaml
+++ b/internal/context/testdata/invalid-config/daco.yaml
@@ -1,0 +1,4 @@
+version: 99
+path: spec
+schema:
+  organization: modular

--- a/internal/context/testdata/missing-spec/daco.yaml
+++ b/internal/context/testdata/missing-spec/daco.yaml
@@ -1,0 +1,4 @@
+version: 1
+path: spec
+schema:
+  organization: modular

--- a/internal/context/testdata/valid/daco.yaml
+++ b/internal/context/testdata/valid/daco.yaml
@@ -1,0 +1,4 @@
+version: 1
+path: spec
+schema:
+  organization: modular

--- a/internal/context/testdata/valid/spec/opendpi.yaml
+++ b/internal/context/testdata/valid/spec/opendpi.yaml
@@ -1,0 +1,27 @@
+# Minimal OpenDPI Example
+# This is the simplest valid OpenDPI document
+
+opendpi: "1.0.0"
+
+info:
+  title: My Data Product
+  version: "1.0.0"
+
+connections:
+  database:
+    protocol: postgresql
+    host: localhost:5432
+
+ports:
+  users:
+    connections:
+      - connection:
+          $ref: "#/connections/database"
+        location: users
+    schema:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string


### PR DESCRIPTION
- Add internal/context package that loads project config and OpenDPI spec from the current working directory
- Provides Cobra integration via PersistentPreRunE for automatic context loading in command groups

## Usage

```go
// Parent command loads context for all subcommands
cmd := &cobra.Command{
    Use:               "ports",
    PersistentPreRunE: context.PreRunLoad,
}

// Subcommands access config and spec via context
func runList(cmd *cobra.Command, args []string) error {
    ctx, err := context.RequireFromCommand(cmd)
    if err != nil {
        return err
    }
    
    // Access config
    fmt.Println(ctx.Config.Path)
    fmt.Println(ctx.Config.Schema.Organization)
    
    // Access spec
    fmt.Println(ctx.Spec.Info.Title)
    for name, port := range ctx.Spec.Ports {
        fmt.Println(name, port.Description)
    }
    return nil
}
```