### PR TITLE
add new docs and rename file

### DIFF
--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -64,5 +64,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Rename daco.md to index.md
+	oldPath := dir + "/daco.md"
+	newPath := dir + "/index.md"
+	if err := os.Rename(oldPath, newPath); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "error renaming %s to %s: %v\n", oldPath, newPath, err)
+		os.Exit(1)
+	}
+
 	fmt.Printf("Documentation generated in %s\n", dir)
 }

--- a/docs/cli/daco_connections_add.md
+++ b/docs/cli/daco_connections_add.md
@@ -17,7 +17,7 @@ daco connections add [flags]
   daco connections add
 
   # Non-interactive
-  daco connections add -n kafka_prod -p kafka --host broker:9092 --non-interactive
+  daco connections add -n kafka_prod -t kafka --host broker:9092
 ```
 
 ### Options
@@ -27,8 +27,7 @@ daco connections add [flags]
   -h, --help                 help for add
       --host string          Host/endpoint
   -n, --name string          Connection name
-      --non-interactive      Run without prompts
-  -p, --protocol string      Protocol (kafka, postgresql, mysql, s3, http, etc.)
+  -t, --type string          Connection type (kafka, postgresql, mysql, s3, http, etc.)
 ```
 
 ### SEE ALSO

--- a/docs/cli/daco_init.md
+++ b/docs/cli/daco_init.md
@@ -4,8 +4,7 @@ Initialize a new daco project
 
 ### Synopsis
 
-Initialize a new daco project with a daco.yaml configuration file.
-Can create a new spec, use an existing one, or extend a parent config.
+Initialize a new daco project with a daco.yaml configuration file and an OpenDPI spec.
 
 ```
 daco init [flags]
@@ -17,22 +16,17 @@ daco init [flags]
   # Interactive mode
   daco init
 
-  # Non-interactive
-  daco init --name "my-product" --non-interactive
-  daco init --extends ../daco.yaml --non-interactive
+  # Non-interactive (runs automatically when --name is provided)
+  daco init --name "Customer Analytics"
 ```
 
 ### Options
 
 ```
-  -e, --extends string               Path to parent daco.yaml
-  -f, --format string                Spec format (yaml or json) (default "yaml")
-  -h, --help                         help for init
-  -n, --name string                  Project name
-      --non-interactive              Run without prompts (requires --name or --extends)
-  -p, --path string                  Path to spec folder (default "./spec")
-  -s, --schema-organization string   Schema organization (modular, components, or inline) (default "modular")
-  -v, --version string               Initial spec version (default "1.0.0")
+  -d, --description string   Data product description
+  -h, --help                 help for init
+  -n, --name string          Data product name
+  -v, --version string       Initial spec version (default "1.0.0")
 ```
 
 ### SEE ALSO

--- a/docs/cli/daco_ports_add.md
+++ b/docs/cli/daco_ports_add.md
@@ -4,9 +4,8 @@ Add a new port to the OpenDPI spec
 
 ### Synopsis
 
-Add a new port to the OpenDPI spec with schema and connection configuration.
-Ports can have optional schemas (from file or created interactively) and
-connections that define where data flows.
+Add a new port to the OpenDPI spec.
+An empty schema file is created in the schemas/ directory for you to fill in.
 
 ```
 daco ports add [flags]
@@ -18,9 +17,8 @@ daco ports add [flags]
   # Interactive mode
   daco ports add
 
-  # Non-interactive with existing connection
-  daco ports add --name events --schema-file ./schemas/event.json \
-    --connection kafka --location events_topic --non-interactive
+  # Non-interactive
+  daco ports add --name events --connection kafka --location events_topic
 ```
 
 ### Options
@@ -31,8 +29,6 @@ daco ports add [flags]
   -h, --help                 help for add
   -l, --location string      Location (table, topic, path, etc.)
   -n, --name string          Port name
-      --non-interactive      Run without prompts
-  -s, --schema-file string   Path to JSON schema file
 ```
 
 ### SEE ALSO

--- a/docs/cli/daco_ports_translate.md
+++ b/docs/cli/daco_ports_translate.md
@@ -6,7 +6,7 @@ Translate a port schema to a target format
 
 Translate a port schema to a target format.
 
-Available formats: avro, databricks-sql, spark-scala, databricks-scala, spark-sql, pyspark, gotypes, databricks-pyspark, pydantic, python, scala, protobuf
+Available formats: databricks-pyspark, pydantic, python, databricks-sql, scala, protobuf, pyspark, avro, spark-scala, databricks-scala, spark-sql, gotypes
 
 ```
 daco ports translate [flags]
@@ -28,7 +28,7 @@ daco ports translate [flags]
 ### Options
 
 ```
-  -f, --format string       Output format (databricks-scala, spark-sql, avro, databricks-sql, spark-scala, pydantic, python, scala, protobuf, pyspark, gotypes, databricks-pyspark)
+  -f, --format string       Output format (pyspark, avro, spark-scala, databricks-scala, spark-sql, gotypes, databricks-pyspark, pydantic, python, databricks-sql, scala, protobuf)
   -h, --help                help for translate
   -n, --name string         Port name (translates all if not specified)
   -o, --output string       Output file path (only valid when translating a single port)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,4 +20,3 @@ Avro, Protobuf, Go types, and more.
 * [daco connections](daco_connections.md)	 - Manage data product connections
 * [daco init](daco_init.md)	 - Initialize a new daco project
 * [daco ports](daco_ports.md)	 - Manage data product ports
-


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated CLI docs to match simplified commands and behavior, and made the generated docs use index.md as the root for cleaner navigation.

- **New Features**
  - Docs generator now renames docs/cli/daco.md to index.md.
  - connections add: replace --protocol with --type; remove non-interactive example.
  - init: simpler options (name, description, version); non-interactive when --name is given.
  - ports add: creates an empty schema file by default; remove --schema-file and non-interactive from docs.
  - ports translate: reordered format list and updated -f option values.

<sup>Written for commit df6f85be12d07c8eef1809f4573432b3f1d4854c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

