### PR TITLE
fix: preserve external schema  in opendpi.yaml when adding ports

### DIFF
--- a/internal/commands/ports_add.go
+++ b/internal/commands/ports_add.go
@@ -92,10 +92,12 @@ func runPortsAdd(cmd *cobra.Command, ctx *session.Context, opts *portsAddOptions
 	}
 
 	// Build port
+	schemaRef := "schemas/" + name + ".schema.yaml"
 	port := opendpi.Port{
 		Description: description,
+		SchemaRef:   schemaRef,
 		Schema: &jsonschema.Schema{
-			Ref: "schemas/" + name + ".schema.yaml",
+			Ref: schemaRef,
 		},
 	}
 

--- a/internal/opendpi/parse.go
+++ b/internal/opendpi/parse.go
@@ -120,6 +120,7 @@ func (p Parser) Parse(r io.Reader, fsys fs.FS) (*Spec, error) {
 		}
 
 		var portSchema *jsonschema.Schema
+		var schemaRef string
 		if rp.Schema != nil {
 			if rp.Schema.Ref != "" {
 				if strings.HasPrefix(rp.Schema.Ref, "#/") {
@@ -135,6 +136,7 @@ func (p Parser) Parse(r io.Reader, fsys fs.FS) (*Spec, error) {
 					portSchema = resolved
 				} else {
 					// External file ref - already loaded in schemaDefs with full path
+					schemaRef = rp.Schema.Ref
 					resolved, ok := schemaDefs[rp.Schema.Ref]
 					if !ok {
 						return nil, fmt.Errorf("port %q: external schema %q not found", name, rp.Schema.Ref)
@@ -208,6 +210,7 @@ func (p Parser) Parse(r io.Reader, fsys fs.FS) (*Spec, error) {
 			Description: rp.Description,
 			Connections: portConns,
 			Schema:      portSchema,
+			SchemaRef:   schemaRef,
 		}
 	}
 

--- a/internal/opendpi/types.go
+++ b/internal/opendpi/types.go
@@ -44,6 +44,7 @@ type Port struct {
 	Description string
 	Connections []PortConnection
 	Schema      *jsonschema.Schema
+	SchemaRef   string // original external $ref path (e.g. "schemas/user.yaml"), preserved for round-trip
 }
 
 // PortConnection represents a connection-location pair for a port.

--- a/internal/opendpi/writer.go
+++ b/internal/opendpi/writer.go
@@ -70,7 +70,9 @@ func toRaw(spec *Spec) (*rawSpec, error) {
 			})
 		}
 
-		if p.Schema != nil {
+		if p.SchemaRef != "" {
+			rp.Schema = &jsonschema.Schema{Ref: p.SchemaRef}
+		} else if p.Schema != nil {
 			rp.Schema = p.Schema
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves external schema $ref paths in opendpi.yaml when adding ports, so newly created schemas in /schemas are properly referenced. Addresses Linear #80 (schemas created but not referenced).

- **Bug Fixes**
  - ports add: set SchemaRef and $ref to schemas/<name>.schema.yaml.
  - parser: keep external $ref path on Port while resolving schema for in-memory use.
  - writer: prefer SchemaRef to emit $ref instead of inlining schemas.
  - tests: added coverage to ensure external refs are preserved for existing and new ports.

<sup>Written for commit df6a5e4fb8720182f3a4b790014f005c9968a531. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

