### PR TITLE
feat: add product version and upgrade commands

### DIFF
--- a/internal/commands/product_upgrade.go
+++ b/internal/commands/product_upgrade.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dacolabs/cli/internal/opendpi"
+	"github.com/dacolabs/cli/internal/prompts"
+	"github.com/dacolabs/cli/internal/session"
+	"github.com/spf13/cobra"
+)
+
+type productUpgradeOptions struct {
+	bump string
+}
+
+func newProductUpgradeCmd() *cobra.Command {
+	opts := &productUpgradeOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade the data product version",
+		Long: `Upgrade the data product version by bumping major, minor, or patch.
+In interactive mode, a form is shown to select the bump type.`,
+		Example: `  # Interactive mode
+  daco product upgrade
+
+  # Non-interactive
+  daco product upgrade --bump minor`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, err := session.RequireFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+			return runProductUpgrade(cmd, ctx, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.bump, "bump", "b", "", "Bump type: major, minor, or patch")
+
+	return cmd
+}
+
+func runProductUpgrade(cmd *cobra.Command, ctx *session.Context, opts *productUpgradeOptions) error {
+	currentVersion := ctx.Spec.Info.Version
+
+	var bumpType string
+	if cmd.Flags().Changed("bump") {
+		bumpType = opts.bump
+		if bumpType != "major" && bumpType != "minor" && bumpType != "patch" {
+			return fmt.Errorf("--bump must be one of: major, minor, patch")
+		}
+	} else {
+		if err := prompts.RunProductUpgradeForm(&bumpType, currentVersion); err != nil {
+			return err
+		}
+	}
+
+	parts := strings.Split(currentVersion, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid version format %q: expected X.Y.Z", currentVersion)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("invalid major version %q: %w", parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("invalid minor version %q: %w", parts[1], err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return fmt.Errorf("invalid patch version %q: %w", parts[2], err)
+	}
+
+	switch bumpType {
+	case "major":
+		major++
+		minor = 0
+		patch = 0
+	case "minor":
+		minor++
+		patch = 0
+	case "patch":
+		patch++
+	}
+
+	newVersion := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+	ctx.Spec.Info.Version = newVersion
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	specDir := ctx.Config.Path
+	if !filepath.IsAbs(specDir) {
+		specDir = filepath.Join(cwd, specDir)
+	}
+
+	var writer opendpi.Writer
+	if _, err := os.Stat(filepath.Join(specDir, "opendpi.json")); err == nil {
+		writer = opendpi.JSONWriter
+	} else {
+		writer = opendpi.YAMLWriter
+	}
+
+	if err := writer.Write(ctx.Spec, specDir); err != nil {
+		return fmt.Errorf("failed to write spec: %w", err)
+	}
+
+	prompts.PrintResult([]prompts.ResultField{
+		{Label: "Previous version", Value: currentVersion},
+		{Label: "New version", Value: newVersion},
+	}, "✓ Version upgraded")
+
+	return nil
+}

--- a/internal/commands/product_version.go
+++ b/internal/commands/product_version.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+package commands
+
+import (
+	"github.com/dacolabs/cli/internal/prompts"
+	"github.com/dacolabs/cli/internal/session"
+	"github.com/spf13/cobra"
+)
+
+func newProductVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show the data product spec version",
+		Long:  `Show the current version of the data product as defined in the OpenDPI spec.`,
+		Example: `  # Show the product version
+  daco product version`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, err := session.RequireFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+			return runProductVersion(ctx)
+		},
+	}
+	return cmd
+}
+
+func runProductVersion(ctx *session.Context) error {
+	prompts.PrintResult([]prompts.ResultField{
+		{Label: "Version", Value: ctx.Spec.Info.Version},
+	}, "")
+	return nil
+}

--- a/internal/commands/register.go
+++ b/internal/commands/register.go
@@ -54,11 +54,23 @@ and are referenced by ports. Use subcommands to add, list, describe, or remove c
 		newConnectionsListCmd(),
 		newConnectionsRemoveCmd())
 
+	productCmd := &cobra.Command{
+		Use:   "product",
+		Short: "Manage data product metadata",
+		Long: `Manage data product metadata defined in the OpenDPI spec.
+Use subcommands to view or upgrade the product version.`,
+		PersistentPreRunE: session.PreRunLoad,
+	}
+	productCmd.AddCommand(
+		newProductVersionCmd(),
+		newProductUpgradeCmd())
+
 	rootCmd.AddCommand(
 		newInitCmd(),
 		newDescribeCmd(),
 		portsCmd,
-		connsCmd)
+		connsCmd,
+		productCmd)
 	return rootCmd
 }
 

--- a/internal/prompts/product_upgrade.go
+++ b/internal/prompts/product_upgrade.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Daco Labs
+
+package prompts
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+// RunProductUpgradeForm runs the interactive form for selecting a version bump type.
+func RunProductUpgradeForm(bumpType *string, currentVersion string) error {
+	options := []huh.Option[string]{
+		huh.NewOption(fmt.Sprintf("patch  (%s)", previewBump(currentVersion, "patch")), "patch"),
+		huh.NewOption(fmt.Sprintf("minor  (%s)", previewBump(currentVersion, "minor")), "minor"),
+		huh.NewOption(fmt.Sprintf("major  (%s)", previewBump(currentVersion, "major")), "major"),
+	}
+
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("Current version: %s — select bump type", currentVersion)).
+				Options(options...).
+				Value(bumpType),
+		),
+	).WithTheme(Theme()).Run()
+}
+
+// previewBump returns the bumped version string for display purposes.
+func previewBump(version, bumpType string) string {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return "?"
+	}
+
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	patch, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return "?"
+	}
+
+	switch bumpType {
+	case "major":
+		return fmt.Sprintf("%d.0.0", major+1)
+	case "minor":
+		return fmt.Sprintf("%d.%d.0", major, minor+1)
+	case "patch":
+		return fmt.Sprintf("%d.%d.%d", major, minor, patch+1)
+	}
+	return "?"
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a new `product` command group with `version` and `upgrade` subcommands to manage the OpenDPI spec version. Supports interactive bump selection or `--bump` (major/minor/patch) and persists the updated spec.

- **New Features**
  - `daco product version`: prints the current spec version.
  - `daco product upgrade`: bumps major/minor/patch; validates X.Y.Z; shows before/after.
  - Interactive form with preview for each bump type; or use `--bump`.
  - Writes the updated spec, auto-detecting JSON or YAML format.

<sup>Written for commit 5706cc07c6f77b1a39088dceeda7fe904d2f87b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

