### PR TITLE
93 add support for non generic pyspark types

### DIFF
--- a/internal/translate/avro/resolver.go
+++ b/internal/translate/avro/resolver.go
@@ -40,6 +40,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return "array:" + elemType
 }
 
+func (r *resolver) MapType(_, valueType string) string {
+	return "map:" + valueType
+}
+
 func (r *resolver) RefType(defName string) string {
 	return "ref:" + defName
 }

--- a/internal/translate/databrickspyspark/README.md
+++ b/internal/translate/databrickspyspark/README.md
@@ -10,8 +10,10 @@ Translates JSON Schema to Databricks PySpark StructType definitions with metadat
 {
   "type": "object",
   "properties": {
-    "name": { "type": "string" },
-    "age": { "type": "integer" }
+    "name": { "type": "string", "description": "Full name" },
+    "age": { "type": "integer", "minimum": 0, "maximum": 150 },
+    "status": { "type": "integer", "minimum": -128, "maximum": 127 },
+    "price": { "type": "number", "multipleOf": 0.01, "minimum": 0, "maximum": 99999.99 }
   }
 }
 ```
@@ -21,11 +23,15 @@ Translates JSON Schema to Databricks PySpark StructType definitions with metadat
 ```python
 import pyspark.sql.types as T
 
-users_schema = T.StructType([
-    T.StructField("name", T.StringType(), nullable=True),
-    T.StructField("age", T.LongType(), nullable=True),
+orders_schema = T.StructType([
+    T.StructField("name", T.StringType(), nullable=True, metadata={"comment": "Full name"}),
+    T.StructField("age", T.ShortType(), nullable=True),
+    T.StructField("status", T.ByteType(), nullable=True),
+    T.StructField("price", T.DecimalType(7, 2), nullable=True),
 ])
 ```
+
+When `minimum` and `maximum` are specified, integers are narrowed to the smallest fitting type (`ByteType`, `ShortType`, `IntegerType`, or `LongType`). When `multipleOf` is a decimal fraction (e.g. `0.01`), numbers become `DecimalType` with precision derived from the bounds and scale from `multipleOf`. Descriptions are emitted as `metadata={"comment": ...}`.
 
 ## Supported JSON Schema Features
 
@@ -52,7 +58,7 @@ users_schema = T.StructType([
 ### Object Keywords
 - [x] properties
 - [x] required
-- [ ] additionalProperties
+- [x] additionalProperties
 - [ ] patternProperties
 - [ ] propertyNames
 - [ ] minProperties / maxProperties
@@ -69,9 +75,9 @@ users_schema = T.StructType([
 - [ ] maxContains / minContains
 
 ### Numeric Validation
-- [ ] minimum / maximum
+- [x] minimum / maximum
 - [ ] exclusiveMinimum / exclusiveMaximum
-- [ ] multipleOf
+- [x] multipleOf
 
 ### String Validation
 - [ ] minLength / maxLength

--- a/internal/translate/databrickspyspark/resolver.go
+++ b/internal/translate/databrickspyspark/resolver.go
@@ -118,13 +118,13 @@ func computeDecimalScale(multipleOf float64) int {
 }
 
 // inferIntegerType returns a narrower integer type if min/max allow it.
-func inferIntegerType(min, max float64) string {
+func inferIntegerType(lo, hi float64) string {
 	switch {
-	case min >= -128 && max <= 127:
+	case lo >= -128 && hi <= 127:
 		return "T.ByteType()"
-	case min >= -32768 && max <= 32767:
+	case lo >= -32768 && hi <= 32767:
 		return "T.ShortType()"
-	case min >= -2147483648 && max <= 2147483647:
+	case lo >= -2147483648 && hi <= 2147483647:
 		return "T.IntegerType()"
 	default:
 		return "T.LongType()"

--- a/internal/translate/databrickspyspark/resolver.go
+++ b/internal/translate/databrickspyspark/resolver.go
@@ -45,6 +45,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("T.ArrayType(%s)", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("T.MapType(%s, %s)", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return "_" + defName
 }

--- a/internal/translate/databrickspyspark/resolver.go
+++ b/internal/translate/databrickspyspark/resolver.go
@@ -6,7 +6,9 @@ package databrickspyspark
 
 import (
 	"fmt"
+	"math"
 	"strconv"
+	"strings"
 
 	"github.com/dacolabs/cli/internal/translate"
 )
@@ -56,8 +58,76 @@ func (r *resolver) FormatRootName(portName string) string {
 }
 
 func (r *resolver) EnrichField(f *translate.Field) {
+	c := f.Constraints
+
+	switch f.Type {
+	case "T.DoubleType()":
+		if c.MultipleOf != nil {
+			if scale := computeDecimalScale(*c.MultipleOf); scale > 0 {
+				precision := computeDecimalPrecision(c.Maximum, scale)
+				f.Type = fmt.Sprintf("T.DecimalType(%d, %d)", precision, scale)
+			}
+		} else if c.Minimum != nil && c.Maximum != nil {
+			f.Type = inferNumberType(*c.Minimum, *c.Maximum)
+		}
+
+	case "T.LongType()":
+		if c.Minimum != nil && c.Maximum != nil {
+			f.Type = inferIntegerType(*c.Minimum, *c.Maximum)
+		}
+	}
+
 	if f.Description != "" {
 		escaped := strconv.Quote(f.Description)
 		f.Tag = `, metadata={"comment": ` + escaped + `}`
 	}
+}
+
+// computeDecimalPrecision derives precision from maximum if available.
+// Returns 38 (Spark default) if maximum is nil.
+func computeDecimalPrecision(maximum *float64, scale int) int {
+	if maximum == nil {
+		return 38
+	}
+	max := math.Abs(*maximum)
+	if max < 1 {
+		return scale
+	}
+	intDigits := len(strconv.FormatFloat(math.Floor(max), 'f', 0, 64))
+	return intDigits + scale
+}
+
+// computeDecimalScale returns the number of decimal places in multipleOf.
+// Returns -1 if multipleOf is >= 1 (not a decimal fraction).
+func computeDecimalScale(multipleOf float64) int {
+	if multipleOf >= 1 || multipleOf <= 0 {
+		return -1
+	}
+	s := strconv.FormatFloat(multipleOf, 'f', -1, 64)
+	if i := strings.Index(s, "."); i >= 0 {
+		return len(s) - i - 1
+	}
+	return -1
+}
+
+// inferIntegerType returns a narrower integer type if min/max allow it.
+func inferIntegerType(min, max float64) string {
+	switch {
+	case min >= -128 && max <= 127:
+		return "T.ByteType()"
+	case min >= -32768 && max <= 32767:
+		return "T.ShortType()"
+	case min >= -2147483648 && max <= 2147483647:
+		return "T.IntegerType()"
+	default:
+		return "T.LongType()"
+	}
+}
+
+// inferNumberType returns FloatType if min/max fit in float32 bounds.
+func inferNumberType(min, max float64) string {
+	if min >= -math.MaxFloat32 && max <= math.MaxFloat32 {
+		return "T.FloatType()"
+	}
+	return "T.DoubleType()"
 }

--- a/internal/translate/databrickspyspark/resolver.go
+++ b/internal/translate/databrickspyspark/resolver.go
@@ -64,7 +64,7 @@ func (r *resolver) EnrichField(f *translate.Field) {
 	case "T.DoubleType()":
 		if c.MultipleOf != nil {
 			if scale := computeDecimalScale(*c.MultipleOf); scale > 0 {
-				precision := computeDecimalPrecision(c.Maximum, scale)
+				precision := computeDecimalPrecision(c.Minimum, c.Maximum, scale)
 				f.Type = fmt.Sprintf("T.DecimalType(%d, %d)", precision, scale)
 			}
 		} else if c.Minimum != nil && c.Maximum != nil {
@@ -83,17 +83,24 @@ func (r *resolver) EnrichField(f *translate.Field) {
 	}
 }
 
-// computeDecimalPrecision derives precision from maximum if available.
-// Returns 38 (Spark default) if maximum is nil.
-func computeDecimalPrecision(maximum *float64, scale int) int {
-	if maximum == nil {
+// computeDecimalPrecision derives precision from minimum and maximum bounds.
+// Returns 38 (Spark default) if both bounds are nil.
+func computeDecimalPrecision(minimum, maximum *float64, scale int) int {
+	var absMax float64
+	switch {
+	case minimum != nil && maximum != nil:
+		absMax = math.Max(math.Abs(*minimum), math.Abs(*maximum))
+	case maximum != nil:
+		absMax = math.Abs(*maximum)
+	case minimum != nil:
+		absMax = math.Abs(*minimum)
+	default:
 		return 38
 	}
-	max := math.Abs(*maximum)
-	if max < 1 {
+	if absMax < 1 {
 		return scale
 	}
-	intDigits := len(strconv.FormatFloat(math.Floor(max), 'f', 0, 64))
+	intDigits := len(strconv.FormatFloat(math.Floor(absMax), 'f', 0, 64))
 	return intDigits + scale
 }
 
@@ -124,10 +131,7 @@ func inferIntegerType(min, max float64) string {
 	}
 }
 
-// inferNumberType returns FloatType if min/max fit in float32 bounds.
+// inferNumberType returns the Spark type for a JSON number field.
 func inferNumberType(min, max float64) string {
-	if min >= -math.MaxFloat32 && max <= math.MaxFloat32 {
-		return "T.FloatType()"
-	}
 	return "T.DoubleType()"
 }

--- a/internal/translate/databrickspyspark/resolver.go
+++ b/internal/translate/databrickspyspark/resolver.go
@@ -65,6 +65,11 @@ func (r *resolver) EnrichField(f *translate.Field) {
 		if c.MultipleOf != nil {
 			if scale := computeDecimalScale(*c.MultipleOf); scale > 0 {
 				precision := computeDecimalPrecision(c.Maximum, scale)
+				if c.Minimum != nil {
+					if minPrecision := computeDecimalPrecision(c.Minimum, scale); minPrecision > precision {
+						precision = minPrecision
+					}
+				}
 				f.Type = fmt.Sprintf("T.DecimalType(%d, %d)", precision, scale)
 			}
 		} else if c.Minimum != nil && c.Maximum != nil {

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -324,6 +324,103 @@ func TestTranslate_MetadataComment(t *testing.T) {
 	assert.NotContains(t, result, `"name", T.StringType(), nullable=True, metadata=`)
 }
 
+func TestTranslate_DecimalType(t *testing.T) {
+	multipleOf := 0.01
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"price": {Type: "number", MultipleOf: &multipleOf},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("order", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.DecimalType(38, 2)")
+}
+
+func TestTranslate_DecimalTypeWithMaximum(t *testing.T) {
+	multipleOf := 0.01
+	max := 99999.99
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"price": {Type: "number", MultipleOf: &multipleOf, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("order", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.DecimalType(7, 2)")
+}
+
+func TestTranslate_FloatType(t *testing.T) {
+	min := -1000.0
+	max := 1000.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"temperature": {Type: "number", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("sensor", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.FloatType()")
+}
+
+func TestTranslate_IntegerType(t *testing.T) {
+	min := 0.0
+	max := 2147483647.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"count": {Type: "integer", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.IntegerType()")
+}
+
+func TestTranslate_ByteType(t *testing.T) {
+	min := 0.0
+	max := 127.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"flags": {Type: "integer", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.ByteType()")
+}
+
+func TestTranslate_DecimalWithMetadata(t *testing.T) {
+	multipleOf := 0.01
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"price": {Type: "number", MultipleOf: &multipleOf, Description: "Product price"},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("order", schema, "schemas")
+	require.NoError(t, err)
+
+	result := string(output)
+	assert.Contains(t, result, "T.DecimalType(38, 2)")
+	assert.Contains(t, result, `metadata={"comment": "Product price"}`)
+}
+
 func TestFileExtension(t *testing.T) {
 	translator := &Translator{}
 	assert.Equal(t, ".py", translator.FileExtension())

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -368,7 +368,7 @@ func TestTranslate_NumberWithBoundsIsDouble(t *testing.T) {
 	translator := &Translator{}
 	output, err := translator.Translate("sensor", schema, "schemas")
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "T.FloatType()")
+	assert.Contains(t, string(output), "T.DoubleType()")
 }
 
 func TestTranslate_IntegerType(t *testing.T) {

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -352,7 +352,7 @@ func TestTranslate_DecimalTypeWithMaximum(t *testing.T) {
 	translator := &Translator{}
 	output, err := translator.Translate("order", schema, "schemas")
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "T.DecimalType(7, 2)")
+	assert.Contains(t, string(output), "T.DecimalType(38, 2)")
 }
 
 func TestTranslate_FloatType(t *testing.T) {

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -368,7 +368,7 @@ func TestTranslate_NumberWithBoundsIsDouble(t *testing.T) {
 	translator := &Translator{}
 	output, err := translator.Translate("sensor", schema, "schemas")
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "T.DoubleType()")
+	assert.Contains(t, string(output), "T.FloatType()")
 }
 
 func TestTranslate_IntegerType(t *testing.T) {

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -355,7 +355,7 @@ func TestTranslate_DecimalTypeWithMaximum(t *testing.T) {
 	assert.Contains(t, string(output), "T.DecimalType(7, 2)")
 }
 
-func TestTranslate_FloatType(t *testing.T) {
+func TestTranslate_NumberWithBoundsIsDouble(t *testing.T) {
 	min := -1000.0
 	max := 1000.0
 	schema := &jsonschema.Schema{
@@ -368,7 +368,7 @@ func TestTranslate_FloatType(t *testing.T) {
 	translator := &Translator{}
 	output, err := translator.Translate("sensor", schema, "schemas")
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "T.FloatType()")
+	assert.Contains(t, string(output), "T.DoubleType()")
 }
 
 func TestTranslate_IntegerType(t *testing.T) {

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -368,7 +368,7 @@ func TestTranslate_FloatType(t *testing.T) {
 	translator := &Translator{}
 	output, err := translator.Translate("sensor", schema, "schemas")
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "T.FloatType()")
+	assert.Contains(t, string(output), "T.DoubleType()")
 }
 
 func TestTranslate_IntegerType(t *testing.T) {

--- a/internal/translate/databrickspyspark/translator_test.go
+++ b/internal/translate/databrickspyspark/translator_test.go
@@ -421,6 +421,40 @@ func TestTranslate_DecimalWithMetadata(t *testing.T) {
 	assert.Contains(t, result, `metadata={"comment": "Product price"}`)
 }
 
+func TestTranslate_MapType(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"tags": {
+				Type:                 "object",
+				AdditionalProperties: &jsonschema.Schema{Type: "string"},
+			},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.MapType(T.StringType(), T.StringType())")
+}
+
+func TestTranslate_MapTypeWithIntegerValues(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"counts": {
+				Type:                 "object",
+				AdditionalProperties: &jsonschema.Schema{Type: "integer"},
+			},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.MapType(T.StringType(), T.LongType())")
+}
+
 func TestFileExtension(t *testing.T) {
 	translator := &Translator{}
 	assert.Equal(t, ".py", translator.FileExtension())

--- a/internal/translate/databricksscala/resolver.go
+++ b/internal/translate/databricksscala/resolver.go
@@ -43,6 +43,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("ArrayType(%s)", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("MapType(%s, %s)", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return "_" + defName
 }

--- a/internal/translate/databrickssql/resolver.go
+++ b/internal/translate/databrickssql/resolver.go
@@ -43,6 +43,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("ARRAY<%s>", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("MAP<%s, %s>", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return defName
 }

--- a/internal/translate/dqxyaml/resolver.go
+++ b/internal/translate/dqxyaml/resolver.go
@@ -18,6 +18,10 @@ func (r *resolver) ArrayType(_ string) string {
 	return "array"
 }
 
+func (r *resolver) MapType(_, _ string) string {
+	return "object"
+}
+
 func (r *resolver) RefType(defName string) string {
 	return translate.ToPascalCase(defName)
 }

--- a/internal/translate/gotypes/resolver.go
+++ b/internal/translate/gotypes/resolver.go
@@ -40,6 +40,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return "[]" + elemType
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return "map[" + keyType + "]" + valueType
+}
+
 func (r *resolver) RefType(defName string) string {
 	return toPascalCase(defName)
 }

--- a/internal/translate/markdown/resolver.go
+++ b/internal/translate/markdown/resolver.go
@@ -18,6 +18,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return "array(" + elemType + ")"
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return "map(" + keyType + ", " + valueType + ")"
+}
+
 func (r *resolver) RefType(defName string) string {
 	return "[" + translate.ToPascalCase(defName) + "](#" + translate.ToPascalCase(defName) + ")"
 }

--- a/internal/translate/prepare.go
+++ b/internal/translate/prepare.go
@@ -114,6 +114,13 @@ func (c *prepareContext) resolveType(schema *jsonschema.Schema, fieldName, path 
 		return c.resolver.ArrayType(c.resolver.PrimitiveType("string", ""))
 	}
 
+	// Handle map types — object with additionalProperties but no properties
+	if (schema.Type == "object" || schema.Type == "") && schema.AdditionalProperties != nil && len(schema.Properties) == 0 {
+		valueType := c.resolveType(schema.AdditionalProperties, fieldName, path)
+		keyType := c.resolver.PrimitiveType("string", "")
+		return c.resolver.MapType(keyType, valueType)
+	}
+
 	// Handle inline objects — extract as a named type definition
 	if schema.Type == "object" || (schema.Type == "" && len(schema.Properties) > 0) {
 		defName := ToPascalCase(fieldName)

--- a/internal/translate/prepare.go
+++ b/internal/translate/prepare.go
@@ -116,7 +116,8 @@ func (c *prepareContext) resolveType(schema *jsonschema.Schema, fieldName, path 
 
 	// Handle map types — object with additionalProperties but no properties
 	if (schema.Type == "object" || schema.Type == "") && schema.AdditionalProperties != nil && len(schema.Properties) == 0 {
-		valueType := c.resolveType(schema.AdditionalProperties, fieldName, path)
+		apPath := path + ".additionalProperties"
+		valueType := c.resolveType(schema.AdditionalProperties, fieldName, apPath)
 		keyType := c.resolver.PrimitiveType("string", "")
 		return c.resolver.MapType(keyType, valueType)
 	}

--- a/internal/translate/prepare_test.go
+++ b/internal/translate/prepare_test.go
@@ -25,6 +25,10 @@ func (s *stubResolver) ArrayType(elemType string) string {
 	return "[]" + elemType
 }
 
+func (s *stubResolver) MapType(keyType, valueType string) string {
+	return "map[" + keyType + "]" + valueType
+}
+
 func (s *stubResolver) RefType(defName string) string {
 	return defName
 }

--- a/internal/translate/protobuf/resolver.go
+++ b/internal/translate/protobuf/resolver.go
@@ -28,6 +28,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return "repeated " + elemType
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return "map<" + keyType + ", " + valueType + ">"
+}
+
 func (r *resolver) RefType(defName string) string {
 	return translate.ToPascalCase(defName)
 }

--- a/internal/translate/pydantic/resolver.go
+++ b/internal/translate/pydantic/resolver.go
@@ -38,6 +38,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return "list[" + elemType + "]"
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return "dict[" + keyType + ", " + valueType + "]"
+}
+
 func (r *resolver) RefType(defName string) string {
 	return translate.ToPascalCase(defName)
 }

--- a/internal/translate/pyspark/README.md
+++ b/internal/translate/pyspark/README.md
@@ -11,7 +11,9 @@ Translates JSON Schema to PySpark StructType definitions (.py).
   "type": "object",
   "properties": {
     "name": { "type": "string" },
-    "age": { "type": "integer" }
+    "age": { "type": "integer", "minimum": 0, "maximum": 150 },
+    "status": { "type": "integer", "minimum": -128, "maximum": 127 },
+    "price": { "type": "number", "multipleOf": 0.01, "minimum": 0, "maximum": 99999.99 }
   }
 }
 ```
@@ -21,11 +23,15 @@ Translates JSON Schema to PySpark StructType definitions (.py).
 ```python
 import pyspark.sql.types as T
 
-users_schema = T.StructType([
+orders_schema = T.StructType([
     T.StructField("name", T.StringType(), nullable=True),
-    T.StructField("age", T.LongType(), nullable=True),
+    T.StructField("age", T.ShortType(), nullable=True),
+    T.StructField("status", T.ByteType(), nullable=True),
+    T.StructField("price", T.DecimalType(7, 2), nullable=True),
 ])
 ```
+
+When `minimum` and `maximum` are specified, integers are narrowed to the smallest fitting type (`ByteType`, `ShortType`, `IntegerType`, or `LongType`). When `multipleOf` is a decimal fraction (e.g. `0.01`), numbers become `DecimalType` with precision derived from the bounds and scale from `multipleOf`.
 
 ## Supported JSON Schema Features
 
@@ -52,7 +58,7 @@ users_schema = T.StructType([
 ### Object Keywords
 - [x] properties
 - [x] required
-- [ ] additionalProperties
+- [x] additionalProperties
 - [ ] patternProperties
 - [ ] propertyNames
 - [ ] minProperties / maxProperties
@@ -69,9 +75,9 @@ users_schema = T.StructType([
 - [ ] maxContains / minContains
 
 ### Numeric Validation
-- [ ] minimum / maximum
+- [x] minimum / maximum
 - [ ] exclusiveMinimum / exclusiveMaximum
-- [ ] multipleOf
+- [x] multipleOf
 
 ### String Validation
 - [ ] minLength / maxLength

--- a/internal/translate/pyspark/resolver.go
+++ b/internal/translate/pyspark/resolver.go
@@ -44,6 +44,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("T.ArrayType(%s)", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("T.MapType(%s, %s)", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return "_" + defName
 }

--- a/internal/translate/pyspark/resolver.go
+++ b/internal/translate/pyspark/resolver.go
@@ -63,7 +63,7 @@ func (r *resolver) EnrichField(f *translate.Field) {
 	case "T.DoubleType()":
 		if c.MultipleOf != nil {
 			if scale := computeDecimalScale(*c.MultipleOf); scale > 0 {
-				precision := computeDecimalPrecision(c.Maximum, scale)
+				precision := computeDecimalPrecision(c.Minimum, c.Maximum, scale)
 				f.Type = fmt.Sprintf("T.DecimalType(%d, %d)", precision, scale)
 				return
 			}
@@ -79,17 +79,24 @@ func (r *resolver) EnrichField(f *translate.Field) {
 	}
 }
 
-// computeDecimalPrecision derives precision from maximum if available.
-// Returns 38 (Spark default) if maximum is nil.
-func computeDecimalPrecision(maximum *float64, scale int) int {
-	if maximum == nil {
+// computeDecimalPrecision derives precision from minimum and maximum bounds.
+// Returns 38 (Spark default) if both bounds are nil.
+func computeDecimalPrecision(minimum, maximum *float64, scale int) int {
+	var absMax float64
+	switch {
+	case minimum != nil && maximum != nil:
+		absMax = math.Max(math.Abs(*minimum), math.Abs(*maximum))
+	case maximum != nil:
+		absMax = math.Abs(*maximum)
+	case minimum != nil:
+		absMax = math.Abs(*minimum)
+	default:
 		return 38
 	}
-	max := math.Abs(*maximum)
-	if max < 1 {
+	if absMax < 1 {
 		return scale
 	}
-	intDigits := len(strconv.FormatFloat(math.Floor(max), 'f', 0, 64))
+	intDigits := len(strconv.FormatFloat(math.Floor(absMax), 'f', 0, 64))
 	return intDigits + scale
 }
 
@@ -120,10 +127,7 @@ func inferIntegerType(min, max float64) string {
 	}
 }
 
-// inferNumberType returns FloatType if min/max fit in float32 bounds.
+// inferNumberType returns the Spark type for a JSON number field.
 func inferNumberType(min, max float64) string {
-	if min >= -math.MaxFloat32 && max <= math.MaxFloat32 {
-		return "T.FloatType()"
-	}
 	return "T.DoubleType()"
 }

--- a/internal/translate/pyspark/resolver.go
+++ b/internal/translate/pyspark/resolver.go
@@ -114,13 +114,13 @@ func computeDecimalScale(multipleOf float64) int {
 }
 
 // inferIntegerType returns a narrower integer type if min/max allow it.
-func inferIntegerType(min, max float64) string {
+func inferIntegerType(lo, hi float64) string {
 	switch {
-	case min >= -128 && max <= 127:
+	case lo >= -128 && hi <= 127:
 		return "T.ByteType()"
-	case min >= -32768 && max <= 32767:
+	case lo >= -32768 && hi <= 32767:
 		return "T.ShortType()"
-	case min >= -2147483648 && max <= 2147483647:
+	case lo >= -2147483648 && hi <= 2147483647:
 		return "T.IntegerType()"
 	default:
 		return "T.LongType()"

--- a/internal/translate/pyspark/resolver.go
+++ b/internal/translate/pyspark/resolver.go
@@ -5,6 +5,9 @@ package pyspark
 
 import (
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 
 	"github.com/dacolabs/cli/internal/translate"
 )
@@ -53,6 +56,74 @@ func (r *resolver) FormatRootName(portName string) string {
 	return portName + "_schema"
 }
 
-func (r *resolver) EnrichField(_ *translate.Field) {
-	// PySpark needs no field enrichment.
+func (r *resolver) EnrichField(f *translate.Field) {
+	c := f.Constraints
+
+	switch f.Type {
+	case "T.DoubleType()":
+		if c.MultipleOf != nil {
+			if scale := computeDecimalScale(*c.MultipleOf); scale > 0 {
+				precision := computeDecimalPrecision(c.Maximum, scale)
+				f.Type = fmt.Sprintf("T.DecimalType(%d, %d)", precision, scale)
+				return
+			}
+		}
+		if c.Minimum != nil && c.Maximum != nil {
+			f.Type = inferNumberType(*c.Minimum, *c.Maximum)
+		}
+
+	case "T.LongType()":
+		if c.Minimum != nil && c.Maximum != nil {
+			f.Type = inferIntegerType(*c.Minimum, *c.Maximum)
+		}
+	}
+}
+
+// computeDecimalPrecision derives precision from maximum if available.
+// Returns 38 (Spark default) if maximum is nil.
+func computeDecimalPrecision(maximum *float64, scale int) int {
+	if maximum == nil {
+		return 38
+	}
+	max := math.Abs(*maximum)
+	if max < 1 {
+		return scale
+	}
+	intDigits := len(strconv.FormatFloat(math.Floor(max), 'f', 0, 64))
+	return intDigits + scale
+}
+
+// computeDecimalScale returns the number of decimal places in multipleOf.
+// Returns -1 if multipleOf is >= 1 (not a decimal fraction).
+func computeDecimalScale(multipleOf float64) int {
+	if multipleOf >= 1 || multipleOf <= 0 {
+		return -1
+	}
+	s := strconv.FormatFloat(multipleOf, 'f', -1, 64)
+	if i := strings.Index(s, "."); i >= 0 {
+		return len(s) - i - 1
+	}
+	return -1
+}
+
+// inferIntegerType returns a narrower integer type if min/max allow it.
+func inferIntegerType(min, max float64) string {
+	switch {
+	case min >= -128 && max <= 127:
+		return "T.ByteType()"
+	case min >= -32768 && max <= 32767:
+		return "T.ShortType()"
+	case min >= -2147483648 && max <= 2147483647:
+		return "T.IntegerType()"
+	default:
+		return "T.LongType()"
+	}
+}
+
+// inferNumberType returns FloatType if min/max fit in float32 bounds.
+func inferNumberType(min, max float64) string {
+	if min >= -math.MaxFloat32 && max <= math.MaxFloat32 {
+		return "T.FloatType()"
+	}
+	return "T.DoubleType()"
 }

--- a/internal/translate/pyspark/translator_test.go
+++ b/internal/translate/pyspark/translator_test.go
@@ -428,7 +428,7 @@ func TestTranslate_NumberWithoutConstraints_DoubleType(t *testing.T) {
 	assert.Contains(t, string(output), "T.DoubleType()")
 }
 
-func TestTranslate_FloatType(t *testing.T) {
+func TestTranslate_NumberWithBoundsIsDouble(t *testing.T) {
 	min := -1000.0
 	max := 1000.0
 	schema := &jsonschema.Schema{
@@ -441,7 +441,7 @@ func TestTranslate_FloatType(t *testing.T) {
 	translator := &Translator{}
 	output, err := translator.Translate("sensor", schema, "schemas")
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "T.FloatType()")
+	assert.Contains(t, string(output), "T.DoubleType()")
 }
 
 func TestTranslate_IntegerType(t *testing.T) {

--- a/internal/translate/pyspark/translator_test.go
+++ b/internal/translate/pyspark/translator_test.go
@@ -558,6 +558,40 @@ func TestTranslate_MultipleOfWholeNumber_NoDecimal(t *testing.T) {
 	assert.Contains(t, string(output), "T.DoubleType()")
 }
 
+func TestTranslate_MapType(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"tags": {
+				Type:                 "object",
+				AdditionalProperties: &jsonschema.Schema{Type: "string"},
+			},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.MapType(T.StringType(), T.StringType())")
+}
+
+func TestTranslate_MapTypeWithIntegerValues(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"counts": {
+				Type:                 "object",
+				AdditionalProperties: &jsonschema.Schema{Type: "integer"},
+			},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.MapType(T.StringType(), T.LongType())")
+}
+
 func TestFileExtension(t *testing.T) {
 	translator := &Translator{}
 	assert.Equal(t, ".py", translator.FileExtension())

--- a/internal/translate/pyspark/translator_test.go
+++ b/internal/translate/pyspark/translator_test.go
@@ -350,6 +350,214 @@ func TestTranslate_RefToComponentsRewritten(t *testing.T) {
 	assert.Contains(t, result, `"user", _User`)
 }
 
+func TestTranslate_DecimalType(t *testing.T) {
+	multipleOf := 0.01
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"price": {Type: "number", MultipleOf: &multipleOf},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("order", schema, "schemas")
+	require.NoError(t, err)
+
+	result := string(output)
+	assert.Contains(t, result, "T.DecimalType(38, 2)")
+}
+
+func TestTranslate_DecimalTypeVaryingScale(t *testing.T) {
+	tests := []struct {
+		multipleOf float64
+		expected   string
+	}{
+		{0.1, "T.DecimalType(38, 1)"},
+		{0.01, "T.DecimalType(38, 2)"},
+		{0.001, "T.DecimalType(38, 3)"},
+		{0.0001, "T.DecimalType(38, 4)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			multipleOf := tt.multipleOf
+			schema := &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"value": {Type: "number", MultipleOf: &multipleOf},
+				},
+			}
+
+			translator := &Translator{}
+			output, err := translator.Translate("data", schema, "schemas")
+			require.NoError(t, err)
+			assert.Contains(t, string(output), tt.expected)
+		})
+	}
+}
+
+func TestTranslate_DecimalTypeRequired(t *testing.T) {
+	multipleOf := 0.01
+	schema := &jsonschema.Schema{
+		Type:     "object",
+		Required: []string{"price"},
+		Properties: map[string]*jsonschema.Schema{
+			"price": {Type: "number", MultipleOf: &multipleOf},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("order", schema, "schemas")
+	require.NoError(t, err)
+
+	result := string(output)
+	assert.Contains(t, result, `"price", T.DecimalType(38, 2), nullable=False`)
+}
+
+func TestTranslate_NumberWithoutConstraints_DoubleType(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"value": {Type: "number"},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.DoubleType()")
+}
+
+func TestTranslate_FloatType(t *testing.T) {
+	min := -1000.0
+	max := 1000.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"temperature": {Type: "number", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("sensor", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.FloatType()")
+}
+
+func TestTranslate_IntegerType(t *testing.T) {
+	min := 0.0
+	max := 2147483647.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"count": {Type: "integer", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.IntegerType()")
+}
+
+func TestTranslate_ShortType(t *testing.T) {
+	min := -32768.0
+	max := 32767.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"small": {Type: "integer", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.ShortType()")
+}
+
+func TestTranslate_ByteType(t *testing.T) {
+	min := 0.0
+	max := 127.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"flags": {Type: "integer", Minimum: &min, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.ByteType()")
+}
+
+func TestTranslate_IntegerWithoutConstraints_LongType(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"big": {Type: "integer"},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "T.LongType()")
+}
+
+func TestTranslate_DecimalTypeWithMaximum(t *testing.T) {
+	multipleOf := 0.01
+	max := 99999.99
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"price": {Type: "number", MultipleOf: &multipleOf, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("order", schema, "schemas")
+	require.NoError(t, err)
+
+	// 99999 = 5 integer digits + 2 scale = precision 7
+	assert.Contains(t, string(output), "T.DecimalType(7, 2)")
+}
+
+func TestTranslate_DecimalTypeWithSmallMaximum(t *testing.T) {
+	multipleOf := 0.001
+	max := 0.999
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"ratio": {Type: "number", MultipleOf: &multipleOf, Maximum: &max},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+
+	// max < 1, so precision = scale = 3
+	assert.Contains(t, string(output), "T.DecimalType(3, 3)")
+}
+
+func TestTranslate_MultipleOfWholeNumber_NoDecimal(t *testing.T) {
+	multipleOf := 1.0
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"qty": {Type: "number", MultipleOf: &multipleOf},
+		},
+	}
+
+	translator := &Translator{}
+	output, err := translator.Translate("data", schema, "schemas")
+	require.NoError(t, err)
+	// multipleOf >= 1 should not trigger DecimalType
+	assert.Contains(t, string(output), "T.DoubleType()")
+}
+
 func TestFileExtension(t *testing.T) {
 	translator := &Translator{}
 	assert.Equal(t, ".py", translator.FileExtension())

--- a/internal/translate/python/resolver.go
+++ b/internal/translate/python/resolver.go
@@ -38,6 +38,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return "list[" + elemType + "]"
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return "dict[" + keyType + ", " + valueType + "]"
+}
+
 func (r *resolver) RefType(defName string) string {
 	return translate.ToPascalCase(defName)
 }

--- a/internal/translate/resolver.go
+++ b/internal/translate/resolver.go
@@ -13,6 +13,9 @@ type TypeResolver interface {
 	// ArrayType wraps an element type string in an array type.
 	ArrayType(elemType string) string
 
+	// MapType wraps key and value type strings in a map type.
+	MapType(keyType, valueType string) string
+
 	// RefType returns the type string for a $ref reference.
 	RefType(defName string) string
 

--- a/internal/translate/scala/resolver.go
+++ b/internal/translate/scala/resolver.go
@@ -42,6 +42,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("List[%s]", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("Map[%s, %s]", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return translate.ToPascalCase(defName)
 }

--- a/internal/translate/sparkscala/resolver.go
+++ b/internal/translate/sparkscala/resolver.go
@@ -42,6 +42,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("ArrayType(%s)", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("MapType(%s, %s)", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return "_" + defName
 }

--- a/internal/translate/sparksql/resolver.go
+++ b/internal/translate/sparksql/resolver.go
@@ -42,6 +42,10 @@ func (r *resolver) ArrayType(elemType string) string {
 	return fmt.Sprintf("ARRAY<%s>", elemType)
 }
 
+func (r *resolver) MapType(keyType, valueType string) string {
+	return fmt.Sprintf("MAP<%s, %s>", keyType, valueType)
+}
+
 func (r *resolver) RefType(defName string) string {
 	return defName
 }


### PR DESCRIPTION
Added support for non generic json schema types 

```
type: object
properties:
  byte_field:
    type: integer
    minimum: 0
    maximum: 127
  short_field:
    type: integer
    minimum: -32768
    maximum: 32767
  integer_field:
    type: integer
    minimum: 0
    maximum: 2147483647
  long_field:
    type: integer
  float_field:
    type: number
    minimum: -1000
    maximum: 1000
  double_field:
    type: number
  decimal_default_precision:
    type: number
    multipleOf: 0.01
  decimal_with_precision:
    type: number
    multipleOf: 0.01
    maximum: 99999.99
  decimal_small:
    type: number
    multipleOf: 0.001
    maximum: 0.999
  string_field:
    type: string
  boolean_field:
    type: boolean
  date_field:
    type: string
    format: date
  datetime_field:
    type: string
    format: date-time
  uuid_field:
    type: string
    format: uuid
```

Translates to 

```
# Code generated by daco; DO NOT EDIT.

import pyspark.sql.types as T

myport_schema = T.StructType([
    T.StructField("byte_field", T.ByteType(), nullable=True),
    T.StructField("short_field", T.ShortType(), nullable=True),
    T.StructField("integer_field", T.IntegerType(), nullable=True),
    T.StructField("long_field", T.LongType(), nullable=True),
    T.StructField("float_field", T.FloatType(), nullable=True),
    T.StructField("double_field", T.DoubleType(), nullable=True),
    T.StructField("decimal_default_precision", T.DecimalType(38, 2), nullable=True),
    T.StructField("decimal_with_precision", T.DecimalType(7, 2), nullable=True),
    T.StructField("decimal_small", T.DecimalType(3, 3), nullable=True),
    T.StructField("string_field", T.StringType(), nullable=True),
    T.StructField("boolean_field", T.BooleanType(), nullable=True),
    T.StructField("date_field", T.DateType(), nullable=True),
    T.StructField("datetime_field", T.TimestampType(), nullable=True),
    T.StructField("uuid_field", T.StringType(), nullable=True),
])

```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds precise numeric inference for `pyspark` and `databrickspyspark`, plus map type support across translators. Addresses Linear #93.

- **New Features**
  - Map types: objects with `additionalProperties` and no `properties` become maps (string keys, inferred value type). Implemented for `pyspark`, `databrickspyspark`, `sparksql`, `databrickssql`, `sparkscala`, `databricksscala`, `protobuf`, `gotypes`, `python`, `pydantic`, `scala`, `markdown`, `dqxyaml`, and `avro`.
  - Numeric inference (`pyspark`, `databrickspyspark`): `number` with decimal `multipleOf` → `T.DecimalType(precision, scale)` (scale from `multipleOf`, precision from bounds; if abs(max) < 1 then precision=scale; default 38). Integers narrow to `T.ByteType()`/`T.ShortType()`/`T.IntegerType()` based on min/max; fallback is `T.LongType()`. Other `number` fields stay `T.DoubleType()`.
  - `databrickspyspark`: preserve field descriptions as `metadata={"comment": ...}`.

<sup>Written for commit 59214eb4725db462c747262fd1b0c3367e843ac1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

