### PR TITLE
Remove use of multipleOf in dqx-yaml

### DIFF
--- a/internal/translate/dqxyaml/translator.go
+++ b/internal/translate/dqxyaml/translator.go
@@ -155,13 +155,6 @@ func collectChecks(colName string, c *translate.Constraints, checks *[]dqxCheck)
 		))
 	}
 
-	// MultipleOf
-	if c.MultipleOf != nil {
-		*checks = append(*checks, newSQLCheck(
-			fmt.Sprintf("%s %% %v = 0", quoteSQL(colName), *c.MultipleOf),
-			fmt.Sprintf("%s must be a multiple of %v", colName, *c.MultipleOf),
-		))
-	}
 
 	// Array constraints
 	if c.MinItems != nil {

--- a/internal/translate/dqxyaml/translator.go
+++ b/internal/translate/dqxyaml/translator.go
@@ -155,7 +155,6 @@ func collectChecks(colName string, c *translate.Constraints, checks *[]dqxCheck)
 		))
 	}
 
-
 	// Array constraints
 	if c.MinItems != nil {
 		*checks = append(*checks, newSQLCheck(

--- a/internal/translate/dqxyaml/translator_test.go
+++ b/internal/translate/dqxyaml/translator_test.go
@@ -403,27 +403,6 @@ func TestTranslate_ArrayConstraints(t *testing.T) {
 	assert.Equal(t, "size(`tags`) <= 10", checks[2].Check.Arguments["expression"])
 }
 
-func TestTranslate_MultipleOf(t *testing.T) {
-	multipleOf := 5.0
-	schema := &jsonschema.Schema{
-		Type:     "object",
-		Required: []string{"quantity"},
-		Properties: map[string]*jsonschema.Schema{
-			"quantity": {
-				Type:       "integer",
-				MultipleOf: &multipleOf,
-			},
-		},
-	}
-
-	checks := translateSchema(t, schema)
-
-	require.Len(t, checks, 2)
-	assertCheck(t, checks[0], "is_not_null", "quantity")
-	assertCheck(t, checks[1], "sql_expression", "")
-	assert.Equal(t, "`quantity` % 5 = 0", checks[1].Check.Arguments["expression"])
-}
-
 func TestTranslate_MultipleConstraints(t *testing.T) {
 	min := 0.0
 	max := 150.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed handling of `multipleOf` in the `dqxyaml` translator so DQX no longer emits SQL modulo checks for this constraint. Aligns with Linear #98 and simplifies schema-to-check translation.

- **Refactors**
  - Dropped `multipleOf` SQL check in `collectChecks` and fixed lint.
  - Removed `TestTranslate_MultipleOf`.

<sup>Written for commit e1f484947e6be5a2a82088e1abc7ef5931834642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

